### PR TITLE
upgrade rest-client gem version 

### DIFF
--- a/ruby-jss.gemspec
+++ b/ruby-jss.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |s|
   # https://github.com/tmtm/ruby-mysql Ruby License (no dependencies)
   s.add_runtime_dependency 'ruby-mysql', '~> 2.9', '>= 2.9.12'
   # https://github.com/rest-client/rest-client & dependencies: MIT License
-  s.add_runtime_dependency 'rest-client', '~> 1.7', '>= 1.7.2'
+  s.add_runtime_dependency 'rest-client', '~> 2.0'
   # https://github.com/ruby-ldap/ruby-net-ldap MIT License (no dependencies)
   s.add_runtime_dependency 'net-ldap', '~> 0.16'
   # https://github.com/stitchfix/immutable-struct MIT License (no dependencies)


### PR DESCRIPTION
Fixing https://github.com/PixarAnimationStudios/ruby-jss/issues/24. 

Tested with ruby 2.4.3 