### PR TITLE
Add attr_reader for certificates

### DIFF
--- a/lib/jss/api_object/computer.rb
+++ b/lib/jss/api_object/computer.rb
@@ -580,6 +580,19 @@ module JSS
     # * :uuid => the ConfigurationProfile uuid
     #
     attr_reader :configuration_profiles
+    
+    # @return [Array<Hash>]
+    #
+    # A Hash for each Certificate on the computer
+    #
+    # The Hash keys are:
+    # * :common_name
+    # * :identity
+    # * :expires_utc
+    # * :expires_epoch
+    # * :name
+    #
+    attr_reader :certificates
 
     # @return [Hash]
     #


### PR DESCRIPTION
Allow certificates to be accessed from JSS Computer objects.