### PR TITLE
Fixes Policy search_by_path erroring

### DIFF
--- a/lib/jss/api_object/policy.rb
+++ b/lib/jss/api_object/policy.rb
@@ -1051,7 +1051,11 @@ module JSS
     # @return [Pathname] The path to search for
     #
     def search_by_path
-      Pathname.new @files_processes[:search_by_path]
+      if @files_processes[:search_by_path].nil?
+        return nil
+      else
+        Pathname.new @files_processes[:search_by_path]
+      end
     end
 
     # @return [Boolean] Should the searched-for path be deleted if found?


### PR DESCRIPTION
Fixes #33 which causes a `JSS::Policy`'s `search_by_path` to error out if the path does not have a string set.
This also enables someone to check for a nil using the `nil?`.