### PR TITLE
Fixed PRINTER_ACTIIONS typo

### DIFF
--- a/lib/jss/api_object/policy.rb
+++ b/lib/jss/api_object/policy.rb
@@ -191,7 +191,7 @@ module JSS
       after: 'After'
     }.freeze
 
-    PRINTER_ACTIIONS = {
+    PRINTER_ACTIONS = {
       map: 'install',
       unmap: 'uninstall'
     }.freeze


### PR DESCRIPTION
This _should_ fix #35 since the typo is fixed in the source.