### PR TITLE
[HotFix] - Fixes printer_names and printer_ids error throwing

### DIFF
--- a/lib/jss/api_object/policy.rb
+++ b/lib/jss/api_object/policy.rb
@@ -1300,16 +1300,22 @@ module JSS
       @dock_items.map { |p| p[:name] }
     end
 
-    ###### Printers
-
     # @return [Array] the id's of the printers handled by the policy
     def printer_ids
-      @printers.map { |p| p[:id] }
+        begin
+            @printers.map { |p| p[:id] }
+            rescue TypeError
+            return []
+        end
     end
-
+    
     # @return [Array] the names of the printers handled by the policy
     def printer_names
-      @printers.map { |p| p[:name] }
+        begin
+            @printers.map { |p| p[:name] }
+            rescue TypeError
+            return []
+        end
     end
 
     ###### Actions


### PR DESCRIPTION
This fixes #37 by catching the TypeError

This is a hotfix, possibly create an empty array first, and then check if the array is empty vs the rescue block.