### PR TITLE
Bugfix/#39

### DIFF
--- a/lib/jss/api_object/group/user_group.rb
+++ b/lib/jss/api_object/group/user_group.rb
@@ -138,6 +138,15 @@ module JSS
       @members.map{|m| m[:email_address]}
     end
 
+    # Override parent's valid_id checker to handle LDAP groups
+    def self.valid_id(identifier, refresh = false, api: JSS.api)
+      if JSS::LDAPServer.group_in_ldap? identifier
+        identifier
+      else
+        super(identifier, refresh, api: api)
+      end
+    end
+        
     #####################################
     ### Private Instance Methods
     #####################################

--- a/lib/jss/api_object/ldap_server.rb
+++ b/lib/jss/api_object/ldap_server.rb
@@ -30,7 +30,7 @@ module JSS
 
   # An LDAP server in the JSS.
   #
-  # This class doesn't curretly provide creation or updaing of LDAP server
+  # This class doesn't curretly provide creation or updating of LDAP server
   # definitions in the JSS. Please use the JSS web UI.
   #
   # However, it does provide methods for querying users and usergroups from

--- a/lib/jss/api_object/scopable/scope.rb
+++ b/lib/jss/api_object/scopable/scope.rb
@@ -204,15 +204,16 @@ module JSS
         if raw_scope[:limitations]
           LIMITATIONS.each do |k|
             raw_scope[:limitations][k] ||= []
-            @limitations[k] = raw_scope[:limitations][k].compact.map { |n| n[:id].to_i }
+            @limitations[k] = raw_scope[:limitations][k].compact.map { |n| n[:name] }
           end # LIMITATIONS.each do |k|
         end # if raw_scope[:limitations]
 
+        #! Does not support Local User Groups, these must be added/removed through the Web UI
         @exclusions = {}
         if raw_scope[:exclusions]
           @exclusion_keys.each do |k|
             raw_scope[:exclusions][k] ||= []
-            @exclusions[k] = raw_scope[:exclusions][k].compact.map { |n| n[:id].to_i }
+            @exclusions[k] = raw_scope[:exclusions][k].compact.map { |n| n[:name] }
           end
         end
 
@@ -517,7 +518,12 @@ module JSS
           list.compact!
           list.delete 0
           list_as_hash = list.map { |i| { id: i } }
-          limitations << SCOPING_CLASSES[klass].xml_list(list_as_hash, :id)
+          if klass == :user_groups || klass == :users
+            list_as_hash = list_as_hash.map { |x| {name: x[:id] } }
+            limitations << SCOPING_CLASSES[klass].xml_list(list_as_hash)
+          else
+            limitations << SCOPING_CLASSES[klass].xml_list(list_as_hash, :id)
+          end
         end
 
         exclusions = scope.add_element('exclusions')
@@ -525,7 +531,13 @@ module JSS
           list.compact!
           list.delete 0
           list_as_hash = list.map { |i| { id: i } }
-          exclusions << SCOPING_CLASSES[klass].xml_list(list_as_hash, :id)
+
+          if klass == :user_groups || klass == :users
+            list_as_hash = list_as_hash.map { |x| {name: x[:id] } }
+            exclusions << SCOPING_CLASSES[klass].xml_list(list_as_hash)
+          else
+            exclusions << SCOPING_CLASSES[klass].xml_list(list_as_hash, :id)
+          end
         end
         scope
       end # scope_xml

--- a/lib/jss/api_object/sitable.rb
+++ b/lib/jss/api_object/sitable.rb
@@ -106,7 +106,11 @@ module JSS
     # @return [Boolean] Does this object have a site assigned?
     #
     def site_assigned?
-      !@site_name.nil?
+      if @site_name == "None"
+        false
+      else
+        !@site_name.nil?
+      end
     end # cat assigned?
 
     # Change the site of this object.

--- a/lib/jss/api_object/user.rb
+++ b/lib/jss/api_object/user.rb
@@ -247,6 +247,15 @@ module JSS
       @need_to_update = true
     end
 
+    # Override parent's valid_id checker to handle LDAP groups
+    def self.valid_id(identifier, refresh = false, api: JSS.api)
+      if JSS::LDAPServer.user_in_ldap? identifier
+        identifier
+      else
+        super(identifier, refresh, api: api)
+      end
+    end
+
 
     #####################################
     ### Private Instance Methods


### PR DESCRIPTION
An issue on JSS::Sitable objects where object sites are usually set to "None" instead of nil. This issue causes objects that don't have sites, unable to be picked out from a list by using the `.site_assigned?` method.

Changes:
- Added a if statement to check for site name being `None` and returns false if it is set to that. Otherwise performs the original check.