### PR TITLE
BugFix: Category object's parse_category not properly referencing API object during execution

### DIFF
--- a/lib/jss/api_object/categorizable.rb
+++ b/lib/jss/api_object/categorizable.rb
@@ -198,7 +198,7 @@ module JSS
 
       if cat.is_a? String
         @category_name = cat
-        @category_id = JSS::Category.category_id_from_name @category_name
+        @category_id = JSS::Category.category_id_from_name @category_name, api: @api
       else
         @category_name = cat[:name]
         @category_id = cat[:id]


### PR DESCRIPTION
This PR should fix #67 a problem where a script, like below, would fail if `JSS.use_api = source` doesn't get executed first, even when `:api` is provided.

```ruby
require 'ruby-jss'

source = JSS::APIConnection.new(
    name: 'source',
    server: 'server.jamfcloud.com',
    user: 'jamfuser',
    pw: :prompt
)

objects = JSS::Printer.all(:refresh, api: source)

#The below should fail on older versions
objects = objects.map { |x| JSS::Priner.fetch(id: x[:id], api: source) }

exit 0
```