### PR TITLE
Computer Group Site Assignment BugFix #66

### DIFF
--- a/lib/jss/api_object/group.rb
+++ b/lib/jss/api_object/group.rb
@@ -458,6 +458,7 @@ module JSS
       group.add_element('is_smart').text = @is_smart
       if @is_smart
         group << @criteria.rest_xml if @criteria
+        group.add_element('computers').text = nil
       else
         group << self.class::MEMBER_CLASS.xml_list(@members, :id)
       end


### PR DESCRIPTION
This PR _should_ fix the bug outlined in #66 where the smart group wouldn't properly update and throw a 409.

The changes made:
- Provided empty computer payload to ensure no conflicts

Details:
The Jamf Pro API assumes you want the same computers included in the group if you don't specify the `<computers><computer /></computers>` section of the XML payload. This is why we get a 409 since one or more computers in the group might not be assigned to the site the group is being moved to.