### PR TITLE
JSS::DirectoryBindingType class object validation changes

### DIFF
--- a/lib/jss/api_object/directory_binding_type/active_directory.rb
+++ b/lib/jss/api_object/directory_binding_type/active_directory.rb
@@ -259,11 +259,17 @@ module JSS
             # @return [void]
             def default_shell=(newvalue)
 
-                # Data Check
-                raise JSS::InvalidDataError, "default_shell must be a string." unless newvalue.is_a? String
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "default_shell must be a string." unless newvalue.is_a? String
+                        newvalue
+                    end
 
                 # Update Value
-                @default_shell = newvalue
+                @default_shell = new
 
                 # Set the object to needing to be updated.
                 self.container&.should_update
@@ -280,12 +286,17 @@ module JSS
             #
             # @return [void]
             def uid=(newvalue)
-
-                # Data Check
-                raise JSS::InvalidDataError, "uid must be either an integer or a string." unless (newvalue.is_a? Integer || newvalue.is_a?(String))
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "uid must be either an integer or a string." unless (newvalue.is_a? Integer || newvalue.is_a?(String))
+                        newvalue
+                    end
 
                 # Update Value
-                @uid = newvalue
+                @uid = new
 
                 # Set the object to needing to be updated.
                 self.container&.should_update
@@ -302,12 +313,17 @@ module JSS
             #
             # @return [void]
             def forest=(newvalue)
-
-                # Data Check
-                raise JSS::InvalidDataError, "forest must be a string." unless newvalue.is_a? String
-
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "forest must be a string." unless newvalue.is_a? String
+                        newvalue
+                    end
+                
                 # Update Value
-                @forest = newvalue
+                @forest = new
 
                 # Set the object to needing to be updated.
                 self.container&.should_update
@@ -323,12 +339,17 @@ module JSS
             #
             # @return [void]
             def user_gid=(newvalue)
-
-                # Data Check
-                raise JSS::InvalidDataError, "user_gid must be either an integer or a string." unless (newvalue.is_a? Integer || newvalue.is_a?(String))
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "user_gid must be either an integer or a string." unless (newvalue.is_a? Integer || newvalue.is_a?(String))
+                        newvalue
+                    end
 
                 # Update Value
-                @user_gid = newvalue
+                @user_gid = new
 
                 # Set the object to needing to be updated.
                 self.container&.should_update
@@ -345,12 +366,17 @@ module JSS
             #
             # @return [void]
             def gid=(newvalue)
-
-                # Data Check
-                raise JSS::InvalidDataError, "gid must be either an integer or a string." unless (newvalue.is_a? Integer || newvalue.is_a?(String))
-
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "gid must be either an integer or a string." unless (newvalue.is_a? Integer || newvalue.is_a?(String))
+                        newvalue
+                    end
+                
                 # Update Value
-                @gid = newvalue
+                @gid = new
 
                 # Set the object to needing to be updated.
                 self.container&.should_update
@@ -389,12 +415,17 @@ module JSS
             #
             # @return [void]
             def preferred_domain=(newvalue)
-
-                # Data Check
-                raise JSS::InvalidDataError, "preferred_domain must be a string." unless newvalue.is_a? String
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "preferred_domain must be a string." unless newvalue.is_a? String
+                        newvalue
+                    end
 
                 # Update Value
-                @preferred_domain = newvalue
+                @preferred_domain = new
 
                 # Set the object to needing to be updated.
                 self.container&.should_update
@@ -411,16 +442,22 @@ module JSS
             #
             # @return [void]
             def admin_groups=(newvalue)
-
-                # Data Check
-                raise JSS::InvalidDataError, "admin_groups must be either a string or an array of strings." unless (newvalue.is_a? String || newvalue.is_a?(Array))
-
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "admin_groups must be either a string or an array of strings." unless (newvalue.is_a? String || newvalue.is_a?(Array))
+                        
+                        if newvalue.is_a? Array
+                            newvalue.join ","
+                        else
+                            newvalue
+                        end
+                    end
+                    
                 # Update Value
-                if newvalue.is_a? Array
-                    @admin_groups = newvalue.join ","
-                else
-                    @admin_groups = newvalue
-                end
+                @admin_groups = new
 
                 # Set the object to needing to be updated.
                 self.container&.should_update

--- a/lib/jss/api_object/directory_binding_type/admitmac.rb
+++ b/lib/jss/api_object/directory_binding_type/admitmac.rb
@@ -181,10 +181,17 @@ module JSS
             #
             # @return [void]
             def local_home=(newvalue)
-                
-                raise JSS::InvalidDataError, "local_home must be one of :#{HOME_FOLDER_TYPE.keys.join(',:')}." unless HOME_FOLDER_TYPE.keys.include? newvalue
 
-                @local_home = HOME_FOLDER_TYPE[newvalue]
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "local_home must be one of :#{HOME_FOLDER_TYPE.keys.join(',:')}." unless HOME_FOLDER_TYPE.keys.include? newvalue
+                        HOME_FOLDER_TYPE[newvalue]
+                    end
+
+                @local_home = new
                 
                 self.container&.should_update
             end
@@ -200,9 +207,16 @@ module JSS
             # @return [void]
             def default_shell=(newvalue)
 
-                raise JSS::InvalidDataError, "default_shell must be empty or a string." unless newvalue.is_a?(String)
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "default_shell must be empty or a string." unless newvalue.is_a?(String)
+                        newvalue
+                    end
 
-                @default_shell = newvalue
+                @default_shell = new
                 
                 self.container&.should_update
             end
@@ -237,9 +251,16 @@ module JSS
             # @return [void]
             def place_home_folders=(newvalue)
 
-                raise JSS::InvalidDataError, "place_home_folders must be a string." unless newvalue.is_a? String
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "place_home_folders must be a string." unless newvalue.is_a? String
+                        newvalue
+                    end
 
-                @place_home_folders = newvalue
+                @place_home_folders = new
                 
                 self.container&.should_update
             end
@@ -259,9 +280,16 @@ module JSS
             # @return [void]
             def uid=(newvalue)
 
-                raise JSS::InvalidDataError, "uid must be a string, integer, or nil." unless newvalue.is_a?(String) || newvalue.is_a?(Integer) || newvalue.nil?
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "uid must be a string, integer, or nil." unless newvalue.is_a?(String) || newvalue.is_a?(Integer) || newvalue.nil?
+                        newvalue
+                    end
 
-                @uid = newvalue
+                @uid = new
                 
                 self.container&.should_update
             end
@@ -278,9 +306,16 @@ module JSS
             # @return [void]
             def user_gid=(newvalue)
 
-                raise JSS::InvalidDataError, "user_gid must be a string, integer, or nil." unless newvalue.is_a?(String) || newvalue.is_a?(Integer) || newvalue.nil?
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "user_gid must be a string, integer, or nil." unless newvalue.is_a?(String) || newvalue.is_a?(Integer) || newvalue.nil?
+                        newvalue
+                    end
 
-                @user_gid = newvalue
+                @user_gid = new
                 
                 self.container&.should_update
             end
@@ -297,9 +332,16 @@ module JSS
             # @return [void]
             def gid=(newvalue)
 
-                raise JSS::InvalidDataError, "gid must be a string, integer, or nil." unless newvalue.is_a?(String) || newvalue.is_a?(Integer) || newvalue.nil?
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "gid must be a string, integer, or nil." unless newvalue.is_a?(String) || newvalue.is_a?(Integer) || newvalue.nil?
+                        newvalue
+                    end
 
-                @gid = newvalue
+                @gid = new
                 
                 self.container&.should_update
             end
@@ -316,10 +358,17 @@ module JSS
             #
             # @return [void]
             def admin_group=(newvalue)
-                
-                raise JSS::InvalidDataError, "An Array must be provided, please use add_admin_group and remove_admin_group for individual group additions and removals." unless newvalue.is_a? Array
 
-                @admin_group = newvalue
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "An Array must be provided, please use add_admin_group and remove_admin_group for individual group additions and removals." unless newvalue.is_a? Array
+                        newvalue
+                    end
+
+                @admin_group = new
                 
                 self.container&.should_update
             end
@@ -336,9 +385,16 @@ module JSS
             # @return [void]
             def cached_credentials=(newvalue)
 
-                raise JSS::InvalidDataError, "cached_credentials must be an integer." unless newvalue.is_a? Integer
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "cached_credentials must be an integer." unless newvalue.is_a? Integer
+                        newvalue
+                    end
 
-                @cached_credentials = newvalue
+                @cached_credentials = new
                 
                 self.container&.should_update
             end
@@ -377,9 +433,16 @@ module JSS
             # @return [void]
             def users_ou=(newvalue)
 
-                raise JSS::InvalidDataError, "users_ou must be either a string or nil." unless newvalue.is_a? String || newvalue.nil?
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "users_ou must be either a string or nil." unless newvalue.is_a? String || newvalue.nil?
+                        newvalue
+                    end
 
-                @users_ou = newvalue
+                @users_ou = new
                 
                 self.container&.should_update
             end
@@ -397,9 +460,16 @@ module JSS
             # @return [void]
             def groups_ou=(newvalue)
 
-                raise JSS::InvalidDataError, "groups_ou must be either a string or nil." unless newvalue.is_a? String || newvalue.nil?
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "groups_ou must be either a string or nil." unless newvalue.is_a? String || newvalue.nil?
+                        newvalue
+                    end
 
-                @groups_ou = newvalue
+                @groups_ou = new
                 
                 self.container&.should_update
             end
@@ -417,9 +487,16 @@ module JSS
             # @return [void]
             def printers_ou=(newvalue)
 
-                raise JSS::InvalidDataError, "printers_ou must be either a string or nil." unless newvalue.is_a? String || newvalue.nil?
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "printers_ou must be either a string or nil." unless newvalue.is_a? String || newvalue.nil?
+                        newvalue
+                    end
 
-                @printers_ou = newvalue
+                @printers_ou = new
                 
                 self.container&.should_update
             end
@@ -437,9 +514,16 @@ module JSS
             # @return [void]
             def shared_folders_ou=(newvalue)
 
-                raise JSS::InvalidDataError, "shared_folders_ou must be either a string or nil." unless newvalue.is_a? String || newvalue.nil?
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "shared_folders_ou must be either a string or nil." unless newvalue.is_a? String || newvalue.nil?
+                        newvalue
+                    end
 
-                @shared_folders_ou = newvalue
+                @shared_folders_ou = new
                 
                 self.container&.should_update
             end

--- a/lib/jss/api_object/directory_binding_type/admitmac.rb
+++ b/lib/jss/api_object/directory_binding_type/admitmac.rb
@@ -162,7 +162,7 @@ module JSS
             # @return [void]
             def require_confirmation=(newvalue)
 
-                raise JSS::InvalidDataError, "require_confirmation must be true or false." unless newvalue.is_a? Bool
+                raise JSS::InvalidDataError, "require_confirmation must be true or false." unless newvalue.is_a?(TrueClass) || newvalue.is_a(FalseClass)
 
                 @require_confirmation = newvalue
                 
@@ -233,7 +233,7 @@ module JSS
             # @return [void]
             def mount_network_home=(newvalue)
 
-                raise JSS::InvalidDataError, "mount_network_home must be true or false." unless newvalue.is_a? Bool
+                raise JSS::InvalidDataError, "mount_network_home must be true or false." unless newvalue.is_a?(TrueClass) || newvalue.is_a(FalseClass)
 
                 @mount_network_home = newvalue
                 
@@ -413,7 +413,7 @@ module JSS
             # @return [void]
             def add_user_to_local=(newvalue)
 
-                raise JSS::InvalidDataError, "add_user_to_local must be true or false." unless newvalue.is_a? Bool
+                raise JSS::InvalidDataError, "add_user_to_local must be true or false." unless newvalue.is_a?(TrueClass) || newvalue.is_a(FalseClass)
 
                 @add_user_to_local = newvalue
                 

--- a/lib/jss/api_object/directory_binding_type/centrify.rb
+++ b/lib/jss/api_object/directory_binding_type/centrify.rb
@@ -106,7 +106,7 @@ module JSS
             # @return [void]
             def workstation_mode=(newvalue)
 
-                raise JSS::InvalidDataError, "workstation_mode must be true or false." unless newvalue.is_a? Bool
+                raise JSS::InvalidDataError, "workstation_mode must be true or false." unless newvalue.is_a?(TrueClass) || newvalue.is_a(FalseClass)
 
                 @workstation_mode = newvalue
 
@@ -125,7 +125,7 @@ module JSS
             # @return [void]
             def overwrite_existing=(newvalue)
 
-                raise JSS::InvalidDataError, "overwrite_existing must be true or false." unless newvalue.is_a? Bool
+                raise JSS::InvalidDataError, "overwrite_existing must be true or false." unless newvalue.is_a?(TrueClass) || newvalue.is_a(FalseClass)
 
                 @overwrite_existing = newvalue
 
@@ -144,7 +144,7 @@ module JSS
             # @return [void]
             def update_PAM=(newvalue)
 
-                raise JSS::InvalidDataError, "update_PAM must be true or false." unless newvalue.is_a? Bool
+                raise JSS::InvalidDataError, "update_PAM must be true or false." unless newvalue.is_a?(TrueClass) || newvalue.is_a(FalseClass)
 
                 @update_PAM = newvalue
 

--- a/lib/jss/api_object/directory_binding_type/centrify.rb
+++ b/lib/jss/api_object/directory_binding_type/centrify.rb
@@ -163,9 +163,16 @@ module JSS
             # @return [void]
             def zone=(newvalue)
 
-                raise JSS::InvalidDataError, "zone must be a string." unless newvalue.is_a? String
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "zone must be a string." unless newvalue.is_a? String
+                        newvalue
+                    end
 
-                @zone = newvalue
+                @zone = new
 
                 self.container&.should_update
             end
@@ -182,9 +189,16 @@ module JSS
             # @return [void]
             def preferred_domain_server=(newvalue)
 
-                raise JSS::InvalidDataError, "preferred_domain_server must be a string." unless newvalue.is_a? String
+                new =
+                    if newvalue.to_s.empty?
+                        JSS::BLANK
+                    else
+                        # Data Check
+                        raise JSS::InvalidDataError, "preferred_domain_server must be a string." unless newvalue.is_a? String
+                        newvalue
+                    end
 
-                @preferred_domain_server = newvalue
+                @preferred_domain_server = new
 
                 self.container&.should_update
             end

--- a/lib/jss/api_object/directory_binding_type/open_directory.rb
+++ b/lib/jss/api_object/directory_binding_type/open_directory.rb
@@ -93,7 +93,7 @@ module JSS
             # @return [void]
             def encrypt_using_ssl=(newvalue)
 
-                raise JSS::InvalidDataError, "encrypt_using_ssl must be true or false." unless newvalue.is_a? Bool
+                raise JSS::InvalidDataError, "encrypt_using_ssl must be true or false." unless newvalue.is_a?(TrueClass) || newvalue.is_a(FalseClass)
                 
                 @encrypt_using_ssl = newvalue
 
@@ -112,7 +112,7 @@ module JSS
             # @return [void]
             def perform_secure_bind=(newvalue)
 
-                raise JSS::InvalidDataError, "perform_secure_bind must be true or false." unless newvalue.is_a? Bool
+                raise JSS::InvalidDataError, "perform_secure_bind must be true or false." unless newvalue.is_a?(TrueClass) || newvalue.is_a(FalseClass)
 
                 @perform_secure_bind = newvalue
 
@@ -131,7 +131,7 @@ module JSS
             # @return [void]
             def use_for_authentication=(newvalue)
 
-                raise JSS::InvalidDataError, "use_for_authentication must be true or false." unless newvalue.is_a? Bool
+                raise JSS::InvalidDataError, "use_for_authentication must be true or false." unless newvalue.is_a?(TrueClass) || newvalue.is_a(FalseClass)
 
                 @use_for_authentication = newvalue
 
@@ -150,7 +150,7 @@ module JSS
             # @return [void]
             def use_for_contacts=(newvalue)
 
-                raise JSS::InvalidDataError, "use_for_contacts must be true or false." unless newvalue.is_a? Bool
+                raise JSS::InvalidDataError, "use_for_contacts must be true or false." unless newvalue.is_a?(TrueClass) || newvalue.is_a(FalseClass)
 
                 @use_for_contacts = newvalue
 


### PR DESCRIPTION
This PR fixes some validation changes outlined in #61, but also addresses some other validation used in other DirectoryBindingType objects which could accept a nil value.

During these changes, discovered improper boolean validation and switch `is_a? Bool` which I used because of other language knowledge and switched to the proper Ruby way of validating Boolean values using `is_a? TrueClass` and `is_a? FalseClass`