### PR TITLE
Faraday::Adapter.use switched to use supported Faraday::Adapter.adapter method

### DIFF
--- a/lib/jamf/api/connection.rb
+++ b/lib/jamf/api/connection.rb
@@ -766,7 +766,7 @@ module Jamf
         cnx.response :json, parser_options: { symbolize_names: true } if parse_json
         cnx.options[:timeout] = @timeout
         cnx.options[:open_timeout] = @open_timeout
-        cnx.use Faraday::Adapter::NetHttp
+        cnx.adapter Faraday::Adapter::NetHttp
       end
     end
 

--- a/lib/jamf/api/connection/token.rb
+++ b/lib/jamf/api/connection/token.rb
@@ -271,7 +271,7 @@ module Jamf
           else
             con.basic_auth @user, pw
           end
-          con.use Faraday::Adapter::NetHttp
+          con.adapter Faraday::Adapter::NetHttp
         end # Faraday.new
       end # token_connection
 


### PR DESCRIPTION
The `.use` method has been depricated, so #80 error is thrown. The fix was to switch the `.use` method with `.adapter` method to properly specify which network adapter class to use.