### PR TITLE
Allows users to be added without providing an ldap server.

### DIFF
--- a/lib/jss/api_object/user.rb
+++ b/lib/jss/api_object/user.rb
@@ -168,7 +168,7 @@ module JSS
       @phone_number = @init_data[:phone_number]
       @position = @init_data[:position]
       @ldap_server = JSS::APIObject.get_name @init_data[:ldap_server]
-      @ldap_server_id = @init_data[:ldap_server][:id]
+      @ldap_server_id = @init_data[:ldap_server][:id] unless @init_data[:ldap_server].nil?
       @sites = @init_data[:sites] ? @init_data[:sites]  : []
 
       if @init_data[:links]


### PR DESCRIPTION
See Issue #87 

Calling JSS::User.make() with just a name throws NoMethodError on line 171, where it assumes that a valid LDAP server has been provided and the appropriate object fetched. As we are not using the LDAP server integration, this prevents us from creating user objects. This change ignores nil LDAP server values.