### PR TITLE
fix: Send mandatory field 'name' with a MobileDeviceApplication request

### DIFF
--- a/lib/jamf/api/classic/api_objects/mobile_device_application.rb
+++ b/lib/jamf/api/classic/api_objects/mobile_device_application.rb
@@ -544,6 +544,7 @@ module Jamf
       doc = REXML::Document.new Jamf::Connection::XML_HEADER
       obj = doc.add_element self.class::RSRC_OBJECT_KEY.to_s
       gen = obj.add_element 'general'
+      gen.add_element('name').text = @display_name
       gen.add_element('display_name').text = @display_name
       gen.add_element('description').text = @description
       gen.add_element('os_type').text = @os_type


### PR DESCRIPTION
With Jamf Pro 10.45.0, it is currently not possible to create a new MobileDeviceApplication using this API implementation.

If a new application is about to be created, the following exception is thrown: 
```
/Users/user/.gem/ruby/2.6.0/gems/ruby-jss-2.1.1/lib/jamf/api/connection/classic_api.rb:290:in `handle_classic_http_error': [!] MobileDeviceApp name is required (Jamf::ConflictError)
from /Users/user/.gem/ruby/2.6.0/gems/ruby-jss-2.1.1/lib/jamf/api/connection/classic_api.rb:112:in `c_post'
from /Users/user/.gem/ruby/2.6.0/gems/ruby-jss-2.1.1/lib/jamf/api/classic/api_objects/creatable.rb:74:in `create_in_jamf'
from /Users/user/.gem/ruby/2.6.0/gems/ruby-jss-2.1.1/lib/jamf/api/classic/base_classes/api_object.rb:1325:in `create'
from /Users/user/.gem/ruby/2.6.0/gems/ruby-jss-2.1.1/lib/jamf/api/classic/api_objects/self_servable.rb:678:in `create'
from /Users/user/.gem/ruby/2.6.0/gems/ruby-jss-2.1.1/lib/jamf/api/classic/base_classes/api_object.rb:1317:in `save'
```

This PR sets the name field for a MobileDeviceApplication creation request.