### PR TITLE
Fix broken config profile updating

### DIFF
--- a/lib/jamf/api/classic/base_classes/configuration_profile.rb
+++ b/lib/jamf/api/classic/base_classes/configuration_profile.rb
@@ -151,7 +151,7 @@ module Jamf
     def payload_content=(new_content)
       payload_plist_data = parsed_payloads
       payload_plist_data['PayloadContent'] = new_content
-      @payloads = JSS.xml_plist_from new_content
+      @payloads = JSS.xml_plist_from payload_plist_data
       @need_to_update = true
       @update_payloads = true
     end


### PR DESCRIPTION
I'm not sure how long this has been the case for, but with Jamf 11.4.2 updating config profile doesn't work.

The last time this code was updated was ~ 3 years ago, and there is still a big warning that this is experimental functionality.

Prior to this change, the behaviour was to upload the XML version of the new profile content, but this wouldn't include the necessary "header" information for a custom config profile and would result in a 409 (conflict) HTTP error.

Now the uploaded payload includes the required pre-amble and the payload contents can be updated as intended.

I've tested this on a non-production Jamf Pro instance running 11.4.2 with both a "standard" profile and a profile that contains a custom payload.

## Standard profile with Passcode payload

The standard profile was a new profile created with just the "Require Passcode" payload enabled.

<img width="794" alt="Screenshot 2024-05-19 at 13 12 43@2x" src="https://github.com/PixarAnimationStudios/ruby-jss/assets/754567/0703fa59-b525-4cfa-ad23-ff1db21a4542">

### Before

```ruby
irb(main):002> profile = Jamf::OSXConfigurationProfile.fetch id: 34
=>
#<Jamf::OSXConfigurationProfile:0x000000010ad3a698
...
irb(main):003> profile_payload_content = profile.payload_content
=>
[{"PayloadDisplayName"=>"Passcode Payload",
...
irb(main):004> profile_payload_content
=>
[{"PayloadDisplayName"=>"Passcode Payload",
  "PayloadIdentifier"=>"1F19B062-41EA-4E6A-BCEF-17EB5D4DA360",
  "PayloadOrganization"=>"JAMF Software",
  "PayloadType"=>"com.apple.mobiledevice.passwordpolicy",
  "PayloadUUID"=>"1F19B062-41EA-4E6A-BCEF-17EB5D4DA360",
  "PayloadVersion"=>1,
  "forcePIN"=>false}]
irb(main):005> profile_payload_content.first["forcePIN"] = true
=> true
irb(main):006> profile.payload_content = profile_payload_content
=>
[{"PayloadDisplayName"=>"Passcode Payload",
...
irb(main):007> profile.save
(irb):7:in `<main>': Jamf::ConflictError (Jamf::ConflictError)
```

### After

```ruby
irb(main):002> profile = Jamf::OSXConfigurationProfile.fetch id: 34
=>
#<Jamf::OSXConfigurationProfile:0x0000000105c53270
...
irb(main):003> profile_payload_content = profile.payload_content
=>
[{"PayloadDisplayName"=>"Passcode Payload",
...
irb(main):004> profile_payload_content.first["forcePIN"] = true
=> true
irb(main):005> profile.payload_content = profile_payload_content
=>
[{"PayloadDisplayName"=>"Passcode Payload",
...
irb(main):006> profile.save
=> nil
```

## Custom profile with Nudge payload

This was also tested with a custom profile that is used for Nudge.

<img width="1154" alt="Screenshot 2024-05-19 at 13 09 50@2x" src="https://github.com/PixarAnimationStudios/ruby-jss/assets/754567/81dcb6c9-78eb-4eed-a513-67e94c15b91b">

### Before

```ruby
irb(main):002> profile = Jamf::OSXConfigurationProfile.fetch id: 10
=>
#<Jamf::OSXConfigurationProfile:0x0000000109d65a10
...
irb(main):003> profile_payload_content = profile.payload_content
=>
[{"PayloadDisplayName"=>"Custom Settings",
...
irb(main):004> profile_payload_content.first.dig('PayloadContent', 'com.github.macadmins.Nudge', 'Forced').first.dig('mcx_preference_settings', 'osVersionRequirements').first["requiredMinimumOSVersion"] = "14.4.1"
=> "14.4.1"
irb(main):005> profile_payload_content
=>
[{"PayloadDisplayName"=>"Custom Settings",
  "PayloadIdentifier"=>"D65A299E-92B3-4BE2-AC31-BA3EB7A840DC",
  "PayloadOrganization"=>"JAMF Software",
  "PayloadType"=>"com.apple.ManagedClient.preferences",
  "PayloadUUID"=>"D65A299E-92B3-4BE2-AC31-BA3EB7A840DC",
  "PayloadVersion"=>1,
  "PayloadContent"=>
   {"com.github.macadmins.Nudge"=>
     {"Forced"=>
       [{"mcx_preference_settings"=>
          {"osVersionRequirements"=>
            [{"requiredInstallationDate"=>"2024-03-01T13:00:00Z", "requiredMinimumOSVersion"=>"14.4.1", "targetedOSVersionsRule"=>"14"},
             {"requiredInstallationDate"=>"2024-03-01T13:00:00Z", "requiredMinimumOSVersion"=>"13.5", "targetedOSVersionsRule"=>"13"}]}}]}}}]
irb(main):006> profile.payload_content = profile_payload_content
=>
[{"PayloadDisplayName"=>"Custom Settings",
...
irb(main):007> profile.save
(irb):7:in `<main>': Jamf::ConflictError (Jamf::ConflictError)
```

### After

```ruby
irb(main):002> profile = Jamf::OSXConfigurationProfile.fetch id: 10
=>
#<Jamf::OSXConfigurationProfile:0x0000000108b49e80
...
irb(main):003> profile_payload_content = profile.payload_content
=>
[{"PayloadDisplayName"=>"Custom Settings",
...
irb(main):004> profile_payload_content.first.dig('PayloadContent', 'com.github.macadmins.Nudge', 'Forced').first.dig('mcx_preference_settings', 'osVersionRequirements').first["requiredMinimumOSVersion"] = "14.4.1"
=> "14.4.1"
irb(main):005> profile_payload_content
=>
[{"PayloadDisplayName"=>"Custom Settings",
  "PayloadIdentifier"=>"D65A299E-92B3-4BE2-AC31-BA3EB7A840DC",
  "PayloadOrganization"=>"JAMF Software",
  "PayloadType"=>"com.apple.ManagedClient.preferences",
  "PayloadUUID"=>"D65A299E-92B3-4BE2-AC31-BA3EB7A840DC",
  "PayloadVersion"=>1,
  "PayloadContent"=>
   {"com.github.macadmins.Nudge"=>
     {"Forced"=>
       [{"mcx_preference_settings"=>
          {"osVersionRequirements"=>
            [{"requiredInstallationDate"=>"2024-03-01T13:00:00Z", "requiredMinimumOSVersion"=>"14.4.1", "targetedOSVersionsRule"=>"14"},
             {"requiredInstallationDate"=>"2024-03-01T13:00:00Z", "requiredMinimumOSVersion"=>"13.5", "targetedOSVersionsRule"=>"13"}]}}]}}}]
irb(main):006> profile.payload_content = profile_payload_content
=>
[{"PayloadDisplayName"=>"Custom Settings",
...
irb(main):007> profile.save
=> nil
```