### PR TITLE
Handle missing properties object during OAPI generation

### DIFF
--- a/bin/generate_object_models
+++ b/bin/generate_object_models
@@ -133,7 +133,7 @@ class App
         #
         #{OAPI_DESC_PLACEHOLDER}
         #
-        # This class was automatically genereated from the #{OAPI_SCHEMA_URL_PATH}
+        # This class was automatically generated from the #{OAPI_SCHEMA_URL_PATH}
         # URL path on a Jamf Pro server version #{JAMF_PRO_VERSION_PLACEHOLDER}
         #
         # This class may be used directly, e.g instances of other classes may


### PR DESCRIPTION
In Jamf Pro 11.5.1 (at least, it's probably been this way for a while) some objects don't have a `properties` field, like the LogOutUserCommand.

To see this, go to yourserver.jamfcloud.com/api/schema and search for the `LogOutUserCommand` definition.

This is what it looks like in 11.5.1 and 11.6.0:

```
      "LogOutUserCommand" : {
        "allOf" : [ {
          "$ref" : "#/components/schemas/MdmCommandBase"
        }, {
          "type" : "object"
        } ]
      },
```

Weirdly, the end of the array had a comment suggesting that this change was once the behaviour. I couldn't find anything in the git history as to why it was changed.

Before this change, running `bin/generate_object_models` would result in the following failure:

```ruby
Doing OAPIObject subclass LocationInformationV2
  file lib/jamf/api/jamf_pro/oapi_schemas/location_information_v2.rb
Doing OAPIObject subclass LocationV2
  file lib/jamf/api/jamf_pro/oapi_schemas/location_v2.rb
Doing OAPIObject subclass LogOutUserCommand
  file lib/jamf/api/jamf_pro/oapi_schemas/log_out_user_command.rb
  Merging properties from MdmCommandBase

***** WARNING ******
Be sure to delete /tmp/generate_opi_objects_jamf_pro_access
if you're done using this tool for a while
***** WARNING ******
bin/generate_object_models:564:in `const_from_properties': undefined method `each' for nil:NilClass (NoMethodError)

    object_schema[:properties].each do |attr, deets|
                              ^^^^^
        from bin/generate_object_models:528:in `block in oapi_properties_const_for_sub_object'
        from bin/generate_object_models:517:in `each'
        from bin/generate_object_models:517:in `oapi_properties_const_for_sub_object'
        from bin/generate_object_models:448:in `class_file_contents'
        from bin/generate_object_models:316:in `process_oapi_object'
        from bin/generate_object_models:191:in `block in run'
        from bin/generate_object_models:190:in `each'
        from bin/generate_object_models:190:in `run'
        from bin/generate_object_models:691:in `<main>'

```

With this change, the process completes.