### PR TITLE
Handle `oneOf` as well as `anyOf`

### DIFF
--- a/bin/generate_object_models
+++ b/bin/generate_object_models
@@ -444,7 +444,7 @@ class App
         oapi_properties_const_for_non_object(class_name, object_schema, enum_consts)
 
       # This schema defines a 'subclass' of another object
-      elsif object_schema[:allOf]
+      elsif object_schema[:allOf] || object_schema[:oneOf]
         oapi_properties_const_for_sub_object(class_name, object_schema, enum_consts)
 
       elsif object_schema[:type] == 'object'
@@ -506,26 +506,28 @@ class App
   # This schema defines a 'subclass' of another object
   ##################################
   def oapi_properties_const_for_sub_object(class_name, object_schema, enum_consts)
-    unless object_schema[:allOf]
-      puts "WARNING: object schema in #{class_name} has no 'allOf'"
+    unless object_schema[:allOf] || object_schema[:oneOf]
+      puts "WARNING: object schema in #{class_name} has no 'allOf' or 'oneOf'"
       return
     end
 
     merges = []
-    const = +"#{OAPI_PROPERTIES_CONST_NAME} = "
+    const = +"#{OAPI_PROPERTIES_CONST_NAME} = {"
 
-    object_schema[:allOf].each do |all_of_item|
+    parent_object = object_schema[:allOf] || object_schema[:oneOf]
+
+    parent_object.each do |item|
       # this item of allOf points to the parent-object
       # We will merge its OAPI_PROPERTIES constant with the one for
       # this object
-      if all_of_item[:$ref]
-        merged_model_name = all_of_item[:$ref].split('/').last
+      if item[:$ref]
+        merged_model_name = item[:$ref].split('/').last
         merges << "Jamf::#{OAPIOBJECT_NAMESPACE}::#{merged_model_name}::#{OAPI_PROPERTIES_CONST_NAME}"
         puts "  Merging properties from #{merged_model_name}"
 
-      # this item of allOf is the schema for the sub-object
+      # this item of allOf or oneOf is the schema for the sub-object
       else
-        const << const_from_properties(all_of_item, enum_consts)
+        const << const_from_properties(item, enum_consts)
       end
     end
 

--- a/bin/generate_object_models
+++ b/bin/generate_object_models
@@ -546,7 +546,7 @@ class App
       return
     end
 
-    const = +"#{OAPI_PROPERTIES_CONST_NAME} = "
+    const = +"#{OAPI_PROPERTIES_CONST_NAME} = {"
     const << const_from_properties(object_schema, enum_consts)
     const << "\n      } # end #{OAPI_PROPERTIES_CONST_NAME}"
     const
@@ -555,7 +555,7 @@ class App
   ########################
   def const_from_properties(object_schema, enum_consts)
     const_def = []
-    const_def << '{'
+    const_def << ''
     const_def << ''
 
     attr_defs = []


### PR DESCRIPTION
Some objects (like `MobileDeviceIosInventory`) don't have any properties beyond `$ref` in their `allOf` or `anyOf`. 

From yourjamfserver.jamfcloud.com/api/schema (this was taken from a server running 11.5.1)

```json
      "MobileDeviceIosInventory" : {
        "allOf" : [ {
          "$ref" : "#/components/schemas/MobileDeviceInventory"
        }, {
          "type" : "object",
          "properties" : {
            "general" : {
              "$ref" : "#/components/schemas/MobileDeviceIosGeneral"
            },
            "security" : {
              "$ref" : "#/components/schemas/MobileDeviceSecurity"
            },
            "ebooks" : {
              "type" : "array",
              "items" : {
                "$ref" : "#/components/schemas/MobileDeviceEbookInventoryDetail"
              }
            },
            "network" : {
              "$ref" : "#/components/schemas/MobileDeviceNetwork"
            },
            "serviceSubscriptions" : {
              "type" : "array",
              "items" : {
                "$ref" : "#/components/schemas/MobileDeviceServiceSubscriptions"
              }
            },
            "provisioningProfiles" : {
              "type" : "array",
              "items" : {
                "$ref" : "#/components/schemas/MobileDeviceProvisioningProfiles"
              }
            },
            "sharedUsers" : {
              "type" : "array",
              "items" : {
                "$ref" : "#/components/schemas/MobileDeviceSharedUser"
              }
            },
            "purchasing" : {
              "$ref" : "#/components/schemas/MobileDevicePurchasing"
            },
            "userProfiles" : {
              "type" : "array",
              "items" : {
                "$ref" : "#/components/schemas/MobileDeviceUserProfile"
              }
            }
          }
        } ]
      },
```

This means they never enter [the `else` case](https://github.com/PixarAnimationStudios/ruby-jss/blob/fffda1f88039c80cc3c4f8f741ac5939ed5a0471/bin/generate_object_models#L527-L529) which previously added the opening {.

https://github.com/PixarAnimationStudios/ruby-jss/blob/fffda1f88039c80cc3c4f8f741ac5939ed5a0471/bin/generate_object_models#L527-L529

By moving the brace outside of `const_from_properties` method, we can make sure it's always present and won't be added twice without some logic to check that the brace is present or not. I think this is simpler.

The second `const_def` line is added to make the diff the same as what is currently present, but it can probably be removed. It makes it easier when reviewing the generated diff now to ensure that nothing has broken.

This might fix #98 (classic Works On My Machine when running with `eager_load = true`, as described in #98, but YMMV).

To be honest, I'm not sure what to check for to see if this is all working or not so keen for a close review by those who understand what's going on.

Also if you want to run `bin/generate_object_models` you probably want to use #99 as well (I couldn't work out how to target the branch from #99 as the base when it's from my fork. Might be a GitHub limitation?)