### PR TITLE
We need vpp_admin_account_id in vpp if we're doing vpp things

### DIFF
--- a/lib/jamf/api/classic/api_objects/vppable.rb
+++ b/lib/jamf/api/classic/api_objects/vppable.rb
@@ -266,6 +266,7 @@ module Jamf
       doc_root = xdoc.root
       vpp = doc_root.add_element 'vpp'
       vpp.add_element('assign_vpp_device_based_licenses').text = @assign_vpp_device_based_licenses.to_s
+      vpp.add_element('vpp_admin_account_id').text = @vpp_admin_account_id.to_s
     end
 
   end # VPPable


### PR DESCRIPTION
Fixed and issue where linking a mobile device application to VPP failed as the vpp_admin_account_id wasn't included in the XML