### PR TITLE
fix configuration preferences in MobileDeviceApplication

### DIFF
--- a/lib/jamf/api/classic/api_objects/mobile_device_application.rb
+++ b/lib/jamf/api/classic/api_objects/mobile_device_application.rb
@@ -561,8 +561,10 @@ module Jamf
       gen.add_element('bundle_id').text = @bundle_id if @host_externally
       gen.add_element('version').text = @version if @host_externally
       gen.add_element('external_url').text = @external_url
-      config = gen.add_element('configuration')
+
+      config = obj.add_element('app_configuration')
       config.add_element('preferences').text = @configuration_prefs
+
       obj << @scope.scope_xml
       add_category_to_xml doc
       add_self_service_xml doc


### PR DESCRIPTION
Spent way too long wondering why my configuration preferences weren't appearing in the App I'd just creating, before realising the parameter was named wrongly, and shouldn't be under the <general> element!

This fixes that issue